### PR TITLE
HEXTER_DEFAULT_PATCH envvar to load a patch file at startup

### DIFF
--- a/src/dx7_voice_data.h
+++ b/src/dx7_voice_data.h
@@ -40,6 +40,7 @@ void dx7_patch_unpack(dx7_patch_t *packed_patch, uint8_t number,
                       uint8_t *unpacked_patch);
 void dx7_patch_pack(uint8_t *unpacked_patch, dx7_patch_t *packed_patch,
                     uint8_t number);
+int  hexter_file_patches_init(dx7_patch_t *patches);
 void hexter_data_patches_init(dx7_patch_t *patches);
 void hexter_data_performance_init(uint8_t *performance);
 


### PR DESCRIPTION
Hello! I wrote this patch for Jean-Michel Thiemonge so he can start hexter with an alternate patch bank in an automated way. I hope this can be usefull for others. I came up with an envvar solution to have something straightforward when using dssi hosts. 
Of course, feel free to modify as much as you wish :)

Good day,
Fabrice.